### PR TITLE
Read piechart fontfill from from self.config.pie.fontfill instead of donut.fontfill

### DIFF
--- a/src/gfx/pie.js
+++ b/src/gfx/pie.js
@@ -35,7 +35,7 @@ uv.PieGraph = function (graphdef, config) {
       .attr('transform', function (d) { return 'translate(' + arcfunc.centroid(d) + ')'; })
       .attr('dy', '.35em')
       .attr('text-anchor', 'middle')
-      .style('fill', self.config.label.showlabel ? self.config.donut.fontfill : 'none')
+      .style('fill', self.config.label.showlabel ? self.config.pie.fontfill : 'none')
       .style('font-family', self.config.pie.fontfamily)
       .style('font-size', self.config.pie.fontsize)
       .style('font-weight', self.config.pie.fontweight)


### PR DESCRIPTION
I noticed the fontfill in the uv.PieGraph is accessing the donut config instead of the pie config.