### PR TITLE
add HTML example for div with id='uv-div' to make requirements more o…

### DIFF
--- a/readme/uvcharts_quick_start_guide.md
+++ b/readme/uvcharts_quick_start_guide.md
@@ -60,6 +60,10 @@ That is a nice dataset we have there for uvCharts. Lets go ahead and plot this i
 
 Thats it, your chart is ready. The chart is by default placed in a DOM element with id 'uv-div' and this can be overridden (more on it later).
 
+Make sure you have a div on your page for the chart to be placed in.
+
+  <div id="uv-div"></div>
+
 Here is the interesting part, no matter which chart you want to represent your data in, the graph definition doesn't change. So if you want to represent the data in the form of a line chart.
 
 	var chart = uv.chart('Line', graphdef);


### PR DESCRIPTION
The current documentation says in English that a div with an id of `uv-div` should be present. This PR adds sample HTML showing a div with that id to make the requirement more obvious.

I'm adding this because I was helping someone get the library set up and requiring that div was not obvious to them.